### PR TITLE
Track research events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
-        "@next-book/analytics": "^0.0.1",
+        "@next-book/analytics": "^0.0.2",
         "@next-book/publisher": "^1.0.2",
         "@types/fscreen": "^1.0.1",
         "@types/lodash": "^4.14.182",
@@ -1482,9 +1482,9 @@
       }
     },
     "node_modules/@next-book/analytics": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.1.tgz",
-      "integrity": "sha512-JR5Hrd8jytir1DzZdgBV4N8DIiKKLs5V5WGDzOPVR6fnqfXC4HEUjh1nDXeJpNT2f+iXmulKMqAj+wRLGaFzvQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.2.tgz",
+      "integrity": "sha512-hL8pAvKN5qrWEX6LdRqg172ft5CpvKo4nTx9CMweAvq7Zchnrv/zPXQZI2jnmzgFLYlBhPC7guYsj8y0of545g==",
       "dependencies": {
         "@fastify/cors": "^8.1.0",
         "@next-book/publisher": "^1.0.2",
@@ -11013,9 +11013,9 @@
       }
     },
     "@next-book/analytics": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.1.tgz",
-      "integrity": "sha512-JR5Hrd8jytir1DzZdgBV4N8DIiKKLs5V5WGDzOPVR6fnqfXC4HEUjh1nDXeJpNT2f+iXmulKMqAj+wRLGaFzvQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.2.tgz",
+      "integrity": "sha512-hL8pAvKN5qrWEX6LdRqg172ft5CpvKo4nTx9CMweAvq7Zchnrv/zPXQZI2jnmzgFLYlBhPC7guYsj8y0of545g==",
       "requires": {
         "@fastify/cors": "^8.1.0",
         "@next-book/publisher": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
+        "@next-book/analytics": "^0.0.1",
         "@next-book/publisher": "^1.0.2",
         "@types/fscreen": "^1.0.1",
         "@types/lodash": "^4.14.182",
@@ -606,6 +607,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.1.2.tgz",
+      "integrity": "sha512-m2nzzQJeuVmeGOB9rnII9sZiY8AZ02a9WMQfMBfK1jxdFnxm3FPYKGbYpPjODj4halNogwpolyugbTNpnDCi0A==",
+      "dependencies": {
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@fastify/cors": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-8.1.0.tgz",
+      "integrity": "sha512-1OmjwyxQZ8GePxa5t1Rpsn2qS56+1ouKMvZufpgJWhXtoCeM/ffA+PsNW8pyslPr4W0E27gVoFqtvHwhXW1U2w==",
+      "dependencies": {
+        "fastify-plugin": "^4.0.0",
+        "mnemonist": "0.39.2"
+      }
+    },
+    "node_modules/@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g=="
+    },
+    "node_modules/@fastify/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg=="
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.0.0.tgz",
+      "integrity": "sha512-9pCi6c6tmGt/qfuf2koZQuSIG6ckP9q3mz+JoMmAq9eQ4EtA92sWoK7E0LJUn2FFTS/hp5kag+4+dWsV5ZfcXg==",
+      "dependencies": {
+        "fast-json-stringify": "^5.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1423,6 +1481,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@next-book/analytics": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.1.tgz",
+      "integrity": "sha512-JR5Hrd8jytir1DzZdgBV4N8DIiKKLs5V5WGDzOPVR6fnqfXC4HEUjh1nDXeJpNT2f+iXmulKMqAj+wRLGaFzvQ==",
+      "dependencies": {
+        "@fastify/cors": "^8.1.0",
+        "@next-book/publisher": "^1.0.2",
+        "@types/ua-parser-js": "^0.7.36",
+        "dotenv": "^16.0.1",
+        "fastify": "^4.3.0",
+        "fastify-plugin": "^4.0.0",
+        "fastify-type-provider-zod": "^1.0.0",
+        "postgres": "^3.2.4",
+        "ua-parser-js": "^1.0.2",
+        "zod": "^3.17.10"
+      }
+    },
     "node_modules/@next-book/publisher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@next-book/publisher/-/publisher-1.0.2.tgz",
@@ -1690,6 +1765,11 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
+    "node_modules/@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
@@ -1914,6 +1994,22 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1990,6 +2086,42 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -2046,6 +2178,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2139,6 +2276,24 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+      "dependencies": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.1"
+      }
     },
     "node_modules/babel-jest": {
       "version": "28.1.1",
@@ -3027,6 +3182,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/editorconfig": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
@@ -3646,6 +3809,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -3798,16 +3969,137 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-json-stringify": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.1.0.tgz",
+      "integrity": "sha512-IybGfbUc1DQgyrp9Myhwlr1Z5vjV37mBkdgcbuvsvUxv5fayG+cHlTQQpXH9nMwUPgp+5Y3RT7QDgx5zJ9NS3A==",
+      "dependencies": {
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fast-redact": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "node_modules/fastify": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.4.0.tgz",
+      "integrity": "sha512-ePI4g9vPJXIBF4YlVcDSLxjvtdTrlM8QzdgYAPFGdCH+rot+4MXoFFAUb10fGrIcRRjaq6CvcbIzxiWQzMMHkw==",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^3.1.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.1.3",
+        "find-my-way": "^7.0.0",
+        "light-my-request": "^5.0.0",
+        "pino": "^8.0.0",
+        "process-warning": "^2.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^8.0.2"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.2.0.tgz",
+      "integrity": "sha512-hovKzEXZc2YgeuXn41/2EA/IaIOdRu1pB9WKgnzDBj3lhKSdDCEsckHa7I6LiT/LhflvAQX7ZY8IQ6eBX0htTg=="
+    },
+    "node_modules/fastify-type-provider-zod": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastify-type-provider-zod/-/fastify-type-provider-zod-1.1.2.tgz",
+      "integrity": "sha512-cYua/PkUSVuFzeInUlO2XMPWBeTiGZq18cWGrm3HVCUEUSoemieDH6iacKohMREEmmkl2W4ukbKbZs0jtRAImw==",
+      "dependencies": {
+        "zod-to-json-schema": "^3.17.1"
+      },
+      "peerDependencies": {
+        "fastify": "^4.0.0",
+        "zod": "^3.14.2"
+      }
+    },
+    "node_modules/fastify/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fastify/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/fastify/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.1",
@@ -3871,6 +4163,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/find-my-way": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.0.1.tgz",
+      "integrity": "sha512-w05SaOPg54KqBof/RDA+75n1R48V7ZZNPL3nR17jJJs5dgZpR3ivfrMWOyx7BVFQgCLhYRG05hfgFCohYvSUXA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "safe-regex2": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -6658,6 +6962,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.4.0.tgz",
+      "integrity": "sha512-lWwUibGSDifLsCGKVy5mCktifWGYiZUCzuKqXgrb3Na7wHPl8aPShxjDhUGQE3MI8k2wJSuvSJh5lyHkMnOTMg==",
+      "dependencies": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6892,6 +7206,14 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.2.tgz",
+      "integrity": "sha512-n3ZCEosuMH03DVivZ9N0fcXPWiZrBLEdfSlEJ+S/mJxmk3zuo1ur0dj9URDczFyP1VS3wfiyKzqLLDXoPJ6rPA==",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -7108,6 +7430,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7299,6 +7631,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.4.1.tgz",
+      "integrity": "sha512-rZnbTUNFiYBH1H2OfYYVNBEFRDhN2nRaEmBD2+MDmGXSGyps+YPJ55LzWZP90zg7zyWKy0ZMqGlk47AO6OaBqQ==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "node_modules/pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -7318,6 +7685,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.2.4.tgz",
+      "integrity": "sha512-iscysD+ZlM4A9zj0RS2zo3f4Us4yuov94Yx+p3dE1rEARaBHC8R3/gRq40KEnWp1lxjuFq9EjuAenIUsPaTaDA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/prelude-ls": {
@@ -7527,6 +7903,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -7621,6 +8002,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7763,6 +8149,17 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg=="
     },
+    "node_modules/readable-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
+      "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
+      "dependencies": {
+        "abort-controller": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7773,6 +8170,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
@@ -7884,6 +8289,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -7939,6 +8352,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "node_modules/rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -7954,6 +8389,22 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "dependencies": {
+        "ret": "~0.2.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8013,6 +8464,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -8085,6 +8541,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8183,6 +8644,14 @@
         "slug": "bin/slug.js"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8209,6 +8678,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -8549,11 +9026,27 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/thread-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.0.1.tgz",
+      "integrity": "sha512-X7vWOdsHLkBq0si20ruEE2ttpS7WOVyD52xKu+TOjrRP9Qi9uB9ynHYpzZUbBptArBSuKYUn4mH+jEBnO2CRGg==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tiny-lru": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-8.0.2.tgz",
+      "integrity": "sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -8798,6 +9291,24 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -8841,7 +9352,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -9391,11 +9901,19 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.17.1.tgz",
+      "integrity": "sha512-h1WLfvkdwM6lcRt5q09ytNh2OKcU13vY9D0FetN/7Erdd7lVraIiMkEnObg3KELm5EQlMqvi0r5nzMa0EA+8qw==",
+      "peerDependencies": {
+        "zod": "^3.17.10"
       }
     }
   },
@@ -9811,6 +10329,61 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
+      }
+    },
+    "@fastify/ajv-compiler": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-3.1.2.tgz",
+      "integrity": "sha512-m2nzzQJeuVmeGOB9rnII9sZiY8AZ02a9WMQfMBfK1jxdFnxm3FPYKGbYpPjODj4halNogwpolyugbTNpnDCi0A==",
+      "requires": {
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
+    "@fastify/cors": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-8.1.0.tgz",
+      "integrity": "sha512-1OmjwyxQZ8GePxa5t1Rpsn2qS56+1ouKMvZufpgJWhXtoCeM/ffA+PsNW8pyslPr4W0E27gVoFqtvHwhXW1U2w==",
+      "requires": {
+        "fastify-plugin": "^4.0.0",
+        "mnemonist": "0.39.2"
+      }
+    },
+    "@fastify/deepmerge": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-1.1.0.tgz",
+      "integrity": "sha512-E8Hfdvs1bG6u0N4vN5Nty6JONUfTdOciyD5rn8KnEsLKIenvOVcr210BQR9t34PRkNyjqnMLGk3e0BsaxRdL+g=="
+    },
+    "@fastify/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-dPRyT40GiHRzSCll3/Jn2nPe25+E1VXc9tDwRAIKwFCxd5Np5wzgz1tmooWG3sV0qKgrBibihVoCna2ru4SEFg=="
+    },
+    "@fastify/fast-json-stringify-compiler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-4.0.0.tgz",
+      "integrity": "sha512-9pCi6c6tmGt/qfuf2koZQuSIG6ckP9q3mz+JoMmAq9eQ4EtA92sWoK7E0LJUn2FFTS/hp5kag+4+dWsV5ZfcXg==",
+      "requires": {
+        "fast-json-stringify": "^5.0.0"
       }
     },
     "@humanwhocodes/config-array": {
@@ -10439,6 +11012,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@next-book/analytics": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@next-book/analytics/-/analytics-0.0.1.tgz",
+      "integrity": "sha512-JR5Hrd8jytir1DzZdgBV4N8DIiKKLs5V5WGDzOPVR6fnqfXC4HEUjh1nDXeJpNT2f+iXmulKMqAj+wRLGaFzvQ==",
+      "requires": {
+        "@fastify/cors": "^8.1.0",
+        "@next-book/publisher": "^1.0.2",
+        "@types/ua-parser-js": "^0.7.36",
+        "dotenv": "^16.0.1",
+        "fastify": "^4.3.0",
+        "fastify-plugin": "^4.0.0",
+        "fastify-type-provider-zod": "^1.0.0",
+        "postgres": "^3.2.4",
+        "ua-parser-js": "^1.0.2",
+        "zod": "^3.17.10"
+      }
+    },
     "@next-book/publisher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@next-book/publisher/-/publisher-1.0.2.tgz",
@@ -10700,6 +11290,11 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
+    "@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
+    },
     "@types/use-sync-external-store": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
@@ -10911,6 +11506,19 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -10966,6 +11574,32 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -11005,6 +11639,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -11074,6 +11713,21 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+    },
+    "avvio": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-8.2.0.tgz",
+      "integrity": "sha512-bbCQdg7bpEv6kGH41RO/3B2/GMMmJSo2iBK+X8AWN9mujtfUipMDfIjsgHCfpnKqoGEQrrmCDKSa5OQ19+fDmg==",
+      "requires": {
+        "archy": "^1.0.0",
+        "debug": "^4.0.0",
+        "fastq": "^1.6.1"
+      }
     },
     "babel-jest": {
       "version": "28.1.1",
@@ -11746,6 +12400,11 @@
         "webidl-conversions": "^7.0.0"
       }
     },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+    },
     "editorconfig": {
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
@@ -12202,6 +12861,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -12321,16 +12985,121 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "fast-json-stringify": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-5.1.0.tgz",
+      "integrity": "sha512-IybGfbUc1DQgyrp9Myhwlr1Z5vjV37mBkdgcbuvsvUxv5fayG+cHlTQQpXH9nMwUPgp+5Y3RT7QDgx5zJ9NS3A==",
+      "requires": {
+        "@fastify/deepmerge": "^1.0.0",
+        "ajv": "^8.10.0",
+        "ajv-formats": "^2.1.1",
+        "fast-uri": "^2.1.0",
+        "rfdc": "^1.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fast-redact": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.1.tgz",
+      "integrity": "sha512-odVmjC8x8jNeMZ3C+rPMESzXVSEU8tSWSHv9HFxP2mm89G/1WwqhrerJDQm9Zus8X6aoRgQDThKqptdNA6bt+A=="
+    },
+    "fast-uri": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-2.1.0.tgz",
+      "integrity": "sha512-qKRta6N7BWEFVlyonVY/V+BMLgFqktCUV0QjT259ekAIlbVrMaFnFLxJ4s/JPl4tou56S1BzPufI60bLe29fHA=="
     },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "fastify": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-4.4.0.tgz",
+      "integrity": "sha512-ePI4g9vPJXIBF4YlVcDSLxjvtdTrlM8QzdgYAPFGdCH+rot+4MXoFFAUb10fGrIcRRjaq6CvcbIzxiWQzMMHkw==",
+      "requires": {
+        "@fastify/ajv-compiler": "^3.1.1",
+        "@fastify/error": "^3.0.0",
+        "@fastify/fast-json-stringify-compiler": "^4.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^8.1.3",
+        "find-my-way": "^7.0.0",
+        "light-my-request": "^5.0.0",
+        "pino": "^8.0.0",
+        "process-warning": "^2.0.0",
+        "proxy-addr": "^2.0.7",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "semver": "^7.3.7",
+        "tiny-lru": "^8.0.2"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "fastify-plugin": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.2.0.tgz",
+      "integrity": "sha512-hovKzEXZc2YgeuXn41/2EA/IaIOdRu1pB9WKgnzDBj3lhKSdDCEsckHa7I6LiT/LhflvAQX7ZY8IQ6eBX0htTg=="
+    },
+    "fastify-type-provider-zod": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastify-type-provider-zod/-/fastify-type-provider-zod-1.1.2.tgz",
+      "integrity": "sha512-cYua/PkUSVuFzeInUlO2XMPWBeTiGZq18cWGrm3HVCUEUSoemieDH6iacKohMREEmmkl2W4ukbKbZs0jtRAImw==",
+      "requires": {
+        "zod-to-json-schema": "^3.17.1"
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -12386,6 +13155,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
+      }
+    },
+    "find-my-way": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.0.1.tgz",
+      "integrity": "sha512-w05SaOPg54KqBof/RDA+75n1R48V7ZZNPL3nR17jJJs5dgZpR3ivfrMWOyx7BVFQgCLhYRG05hfgFCohYvSUXA==",
+      "requires": {
+        "fast-deep-equal": "^3.1.3",
+        "safe-regex2": "^2.0.0"
       }
     },
     "find-up": {
@@ -14420,6 +15198,16 @@
         "type-check": "~0.4.0"
       }
     },
+    "light-my-request": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-5.4.0.tgz",
+      "integrity": "sha512-lWwUibGSDifLsCGKVy5mCktifWGYiZUCzuKqXgrb3Na7wHPl8aPShxjDhUGQE3MI8k2wJSuvSJh5lyHkMnOTMg==",
+      "requires": {
+        "cookie": "^0.5.0",
+        "process-warning": "^2.0.0",
+        "set-cookie-parser": "^2.4.1"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -14599,6 +15387,14 @@
         "minimist": "^1.2.6"
       }
     },
+    "mnemonist": {
+      "version": "0.39.2",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.2.tgz",
+      "integrity": "sha512-n3ZCEosuMH03DVivZ9N0fcXPWiZrBLEdfSlEJ+S/mJxmk3zuo1ur0dj9URDczFyP1VS3wfiyKzqLLDXoPJ6rPA==",
+      "requires": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14758,6 +15554,16 @@
         "es-abstract": "^1.19.1"
       }
     },
+    "obliterator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.4.tgz",
+      "integrity": "sha512-lgHwxlxV1qIg1Eap7LgIeoBWIMFibOjbrYPIPJZcI1mmGAI2m3lNYpK12Y+GBdPQ0U1hRwSord7GIaawz962qQ=="
+    },
+    "on-exit-leak-free": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+      "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+    },
     "on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -14895,6 +15701,38 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="
     },
+    "pino": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.4.1.tgz",
+      "integrity": "sha512-rZnbTUNFiYBH1H2OfYYVNBEFRDhN2nRaEmBD2+MDmGXSGyps+YPJ55LzWZP90zg7zyWKy0ZMqGlk47AO6OaBqQ==",
+      "requires": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.0.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^2.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.1.0",
+        "thread-stream": "^2.0.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+      "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+      "requires": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-std-serializers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
+      "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
+    },
     "pirates": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
@@ -14909,6 +15747,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "postgres": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.2.4.tgz",
+      "integrity": "sha512-iscysD+ZlM4A9zj0RS2zo3f4Us4yuov94Yx+p3dE1rEARaBHC8R3/gRq40KEnWp1lxjuFq9EjuAenIUsPaTaDA=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -15055,6 +15898,11 @@
         }
       }
     },
+    "process-warning": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.0.0.tgz",
+      "integrity": "sha512-+MmoAXoUX+VTHAlwns0h+kFUWFs/3FZy+ZuchkgjyOu3oioLAo2LB5aCfKPh2+P9O18i3m43tUEv3YqttSy0Ww=="
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -15134,6 +15982,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -15226,6 +16079,14 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.1.0.tgz",
+      "integrity": "sha512-sVisi3+P2lJ2t0BPbpK629j8wRW06yKGJUcaLAGXPAUhyUxVJm7VsCTit1PFgT4JHUDMrGNR+ZjSKpzGaRF3zw==",
+      "requires": {
+        "abort-controller": "^3.0.0"
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -15234,6 +16095,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
     },
     "rechoir": {
       "version": "0.7.1",
@@ -15321,6 +16187,11 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -15360,6 +16231,21 @@
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
       "dev": true
     },
+    "ret": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -15372,6 +16258,19 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
+      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "requires": {
+        "ret": "~0.2.0"
+      }
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -15415,6 +16314,11 @@
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "secure-json-parse": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.5.0.tgz",
+      "integrity": "sha512-ZQruFgZnIWH+WyO9t5rWt4ZEGqCKPwhiw+YbzTwpmT9elgLrLcfuyUiSnwwjUiVy9r4VM3urtbNF1xmEh9IL2w=="
     },
     "semver": {
       "version": "6.3.0",
@@ -15482,6 +16386,11 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
+    },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -15561,6 +16470,14 @@
         "unicode": ">= 0.3.1"
       }
     },
+    "sonic-boom": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
+      "integrity": "sha512-SbbZ+Kqj/XIunvIAgUZRlqd6CGQYq71tRRbXR92Za8J/R3Yh4Av+TWENiSiEgnlwckYLyP0YZQWVfyNC0dzLaA==",
+      "requires": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15582,6 +16499,11 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -15821,11 +16743,24 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "thread-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.0.1.tgz",
+      "integrity": "sha512-X7vWOdsHLkBq0si20ruEE2ttpS7WOVyD52xKu+TOjrRP9Qi9uB9ynHYpzZUbBptArBSuKYUn4mH+jEBnO2CRGg==",
+      "requires": {
+        "real-require": "^0.2.0"
+      }
+    },
     "throat": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tiny-lru": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-8.0.2.tgz",
+      "integrity": "sha512-ApGvZ6vVvTNdsmt676grvCkUCGwzG9IqXma5Z07xJgiC5L7akUMof5U8G2JTI9Rz/ovtVhJBlY6mNhEvtjzOIg=="
     },
     "tmpl": {
       "version": "1.0.5",
@@ -15998,6 +16933,11 @@
       "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
       "dev": true
     },
+    "ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
+    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -16029,7 +16969,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -16421,9 +17360,15 @@
       "dev": true
     },
     "zod": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.17.3.tgz",
-      "integrity": "sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.18.0.tgz",
+      "integrity": "sha512-gwTm8RfUCe8l9rDwN5r2A17DkAa8Ez4Yl4yXqc5VqeGaXaJahzYYXbTwvhroZi0SNBqTwh/bKm2N0mpCzuw4bA=="
+    },
+    "zod-to-json-schema": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.17.1.tgz",
+      "integrity": "sha512-h1WLfvkdwM6lcRt5q09ytNh2OKcU13vY9D0FetN/7Erdd7lVraIiMkEnObg3KELm5EQlMqvi0r5nzMa0EA+8qw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
+    "@next-book/analytics": "^0.0.1",
     "@next-book/publisher": "^1.0.2",
     "@types/fscreen": "^1.0.1",
     "@types/lodash": "^4.14.182",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@next-book/analytics": "^0.0.1",
+    "@next-book/analytics": "^0.0.2",
     "@next-book/publisher": "^1.0.2",
     "@types/fscreen": "^1.0.1",
     "@types/lodash": "^4.14.182",

--- a/src/js/components/research/index.tsx
+++ b/src/js/components/research/index.tsx
@@ -11,13 +11,14 @@ import { init as initTracking } from './tracker';
 interface IProps extends WithTranslation {
   consent: Consent;
   denyConsent(): void;
-  grantConsent(ga: string): void;
+  grantConsent(ga: string, id: string): void;
 }
 
 export interface IState {
   active: boolean;
   text?: string;
   orgs?: string;
+  id?: string;
   ga?: string;
 }
 
@@ -34,12 +35,12 @@ class Research extends React.Component<IProps, IState> {
     if (params !== null) {
       this.setState({ ...this.state, ...params, active: true });
 
-      if (this.props.consent === Consent.Granted) initTracking(params.ga);
+      if (this.props.consent === Consent.Granted) initTracking(params.ga, params.id);
     }
   }
 
   grantConsent = () => {
-    if (this.state.ga) this.props.grantConsent(this.state.ga);
+    if (this.state.ga && this.state.id) this.props.grantConsent(this.state.ga, this.state.id);
     else this.props.denyConsent();
   };
 

--- a/src/js/components/research/reducer.ts
+++ b/src/js/components/research/reducer.ts
@@ -34,8 +34,8 @@ reducer.denyConsent = function () {
   };
 };
 
-reducer.grantConsent = function (ga: string) {
-  initTracking(ga);
+reducer.grantConsent = function (ga: string, id: string) {
+  initTracking(ga, id);
 
   return <const>{
     type: GRANT_CONSENT,

--- a/src/js/components/research/tracker.ts
+++ b/src/js/components/research/tracker.ts
@@ -14,14 +14,13 @@ let initialized: boolean = false;
 export const init = (gaId: string, nbId: string) => {
   const path = document.location.pathname;
   const domain = document.location.host + path.substring(path.indexOf('/'), path.lastIndexOf('/'));
-  Tracker.init(nbId, domain, 'http://127.0.0.1:3000', true);
-  console.log('Tracker Initialized');
+  Tracker.init(nbId, domain, 'https://analytics.next-book.info');
   Tracker.send('pageview');
   ReactGA.initialize(gaId);
   ReactGA.pageview();
   initialized = true;
 
-  console.log('Research data collection initialized.');
+  console.log('Research data collection initialized');
 
   setInterval(trackReadingTime(), 1000 * 60 * 10);
 };

--- a/src/js/components/research/tracker.ts
+++ b/src/js/components/research/tracker.ts
@@ -1,5 +1,6 @@
 import ReactGA from 'react-ga4';
 import { SwAvailability } from '../offline/reducer';
+import Tracker from '@next-book/analytics';
 
 enum Category {
   Text = 'text',
@@ -10,12 +11,17 @@ enum Category {
 
 let initialized: boolean = false;
 
-export const init = (id: string) => {
-  ReactGA.initialize(id);
+export const init = (gaId: string, nbId: string) => {
+  const path = document.location.pathname;
+  const domain = document.location.host + path.substring(path.indexOf('/'), path.lastIndexOf('/'));
+  Tracker.init(nbId, domain, 'http://127.0.0.1:3000', true);
+  console.log('Tracker Initialized');
+  Tracker.send('pageview');
+  ReactGA.initialize(gaId);
   ReactGA.pageview();
   initialized = true;
 
-  console.log('Research data collection initialized');
+  console.log('Research data collection initialized.');
 
   setInterval(trackReadingTime(), 1000 * 60 * 10);
 };
@@ -27,7 +33,6 @@ const getMinutes = () => {
 const send = (category: Category, action: string, value?: string | number) => {
   if (initialized) {
     console.log(`Event: ${category}, ${action} (${value}).`);
-
     if (value === undefined) ReactGA.event({ category, action });
     if (typeof value === 'number') ReactGA.event({ category, action, value: value });
     else ReactGA.event({ category, action, label: value });
@@ -39,7 +44,13 @@ export const trackReadingTime = () => {
 
   return () => {
     const curTime = getMinutes();
-    send(Category.Text, 'time-read', curTime - startTime);
+    const time = curTime - startTime;
+    send(Category.Text, 'time-read', time);
+    Tracker.send({
+      name: 'time-read',
+      category: Category.Text,
+      value: time.toString(),
+    });
   };
 };
 
@@ -49,6 +60,11 @@ let trackedAmount: number[] = [];
 export const trackAmountRead = (amount: number) => {
   if (amountsToTrack.includes(amount) && !trackedAmount.includes(amount)) {
     send(Category.Text, 'amount-read', amount);
+    Tracker.send({
+      name: 'amount-read',
+      category: Category.Text,
+      value: amount.toString(),
+    });
     trackedAmount.push(amount);
   }
 };
@@ -75,14 +91,29 @@ export const trackPagination = (controller: Controller) => {
 
 const trackControlType = (type: ControlType, controller: Controller) => {
   send(Category.Interaction, type, controller);
+  Tracker.send({
+    name: type,
+    category: Category.Interaction,
+    method: controller,
+  });
 };
 
 export const trackColorScheme = (scheme: string) => {
   send(Category.UI, 'color-scheme', scheme);
+  Tracker.send({
+    name: 'changed-color-scheme',
+    category: Category.UI,
+    value: scheme,
+  });
 };
 
 export const trackFontSize = (size: string) => {
   send(Category.UI, 'font-size', parseInt(size, 10));
+  Tracker.send({
+    name: 'changed-font-size',
+    category: Category.UI,
+    value: size,
+  });
 };
 
 const openingsToTrack = [1, 2, 10, 20, 100];
@@ -93,34 +124,61 @@ export const trackMenuOpening = () => {
 
   if (openingsToTrack.includes(trackedOpenings)) {
     send(Category.UI, 'menu-opened', trackedOpenings);
+    Tracker.send({
+      name: 'menu-opened',
+      category: Category.UI,
+      value: trackedOpenings.toString(),
+    });
   }
 };
 
 export const trackAnnotationCreation = (symbol: string) => {
   send(Category.Interaction, 'annotation-created', symbol);
+  Tracker.send({
+    name: 'annotation-created',
+    category: Category.Interaction,
+    value: symbol,
+  });
 };
 
 export const trackNoteCreation = () => {
   send(Category.Interaction, 'note-created');
+  Tracker.send({
+    name: 'note-created',
+    category: Category.Interaction,
+  });
 };
 
 export const trackSeqReturned = () => {
   send(Category.UI, 'seq-return', 'returned');
+  Tracker.send({
+    name: 'seq-return',
+    category: Category.UI,
+    value: 'returned',
+  });
 };
 
 export const trackSeqReset = () => {
   send(Category.UI, 'seq-return', 'reset');
+  Tracker.send({
+    name: 'seq-return',
+    category: Category.UI,
+    value: 'reset',
+  });
 };
 
 export const trackOfflineStatus = (swAvailable: SwAvailability) => {
-  switch (swAvailable) {
-    case SwAvailability.Initial:
-      return send(Category.Offline, 'initial');
-    case SwAvailability.Unsecure:
-      return send(Category.Offline, 'unsecure');
-    case SwAvailability.NoSw:
-      return send(Category.Offline, 'no-sw');
-    case SwAvailability.Available:
-      return send(Category.Offline, 'available');
-  }
+  const dictionary: { [key in SwAvailability]: string } = {
+    [SwAvailability.Initial]: 'initial',
+    [SwAvailability.Unsecure]: 'unsecure',
+    [SwAvailability.NoSw]: 'no-sw',
+    [SwAvailability.Available]: 'available',
+  };
+  const availability = dictionary[swAvailable];
+  Tracker.send({
+    name: 'offline-status',
+    category: Category.Offline,
+    value: availability,
+  });
+  return send(Category.Offline, availability);
 };

--- a/src/js/doc-info.ts
+++ b/src/js/doc-info.ts
@@ -141,12 +141,13 @@ export function scrollToIdea(number: number | null) {
   }
 }
 
-export function getResearchParams(): { text: string; orgs: string; ga: string } | null {
+export function getResearchParams(): { text: string; orgs: string; ga: string, id: string } | null {
   const text = getResearchParam(ResearchMetaName.Text);
   const orgs = getResearchParam(ResearchMetaName.Orgs);
   const ga = getResearchParam(ResearchMetaName.GA);
-  if (!text || !orgs || !ga) return null;
+  if (!text || !orgs || !ga || !identifier) return null;
   return {
+    id: identifier,
     text,
     orgs,
     ga,


### PR DESCRIPTION
Adds self-hosted event tracking alongside the GA tracking. At this point, it works only with a linked local version of @next-book/analytics (because the package is not published and thus installed yet) and sends all the events to local server.